### PR TITLE
Fix FFDetrDetector crash when final batch has one page

### DIFF
--- a/commonforms/inference.py
+++ b/commonforms/inference.py
@@ -74,9 +74,10 @@ class FFDetrDetector:
         results = []
         for b in batch([p.image for p in pages], n=batch_size):
             predictions = self.model.predict(b, threshold=confidence)
-            if len(pages) == 1 or batch_size == 1:
-                predictions = [predictions]
-            results.extend(predictions)
+            if isinstance(predictions, list):
+                results.extend(predictions)
+            else:
+                results.append(predictions)
 
         widgets = {}
 
@@ -264,9 +265,14 @@ def prepare_form(
     except pypdfium2._helpers.misc.PdfiumError:
         raise EncryptedPdfError
 
-    results = detector.extract_widgets(
-        pages, confidence=confidence, image_size=image_size
-    )
+    if isinstance(detector, FFDetrDetector):
+        results = detector.extract_widgets(
+            pages, confidence=confidence, image_size=image_size, batch_size=batch_size
+        )
+    else:
+        results = detector.extract_widgets(
+            pages, confidence=confidence, image_size=image_size
+        )
 
     writer = PyPdfFormCreator(input_path)
     if not keep_existing_fields:


### PR DESCRIPTION
Fixes #30 

## Summary
Fixes a crash in `FFDetrDetector.extract_widgets()` when the final batch contains a single page (e.g. `len(pages) % batch_size == 1` and `len(pages) > 1`).

## Root cause
`model.predict()` returns:
- `List[sv.Detections]` for batch size > 1
- `sv.Detections` for batch size == 1

When the final batch size is 1, `results.extend(predictions)` iterates the `sv.Detections` object and adds non-detection items (e.g. tuples) into `results`, which later breaks `.with_nms()`.

## Fix
- Use `append` for single `sv.Detections` and `extend` for lists (ensures `results` is always `List[sv.Detections]`).

## Testing
- Confirmed the crash on main with a 4-page PDF using `batch_size=3` (batches of 3 + 1).
- Confirmed fixed with this change; also tested `batch_size=1`.