### PR TITLE
Fix --help crash, remove debug print, and recommend isolated install

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,30 @@ This repo contains three things:
 
 ## Installation
 
-CommonForms can be installed with either `uv` or `pip`, feel free to choose your package manager flavor:
+CommonForms is a CLI tool with a sizable dependency footprint (`transformers`,
+`torch`, `rfdetr`, `ultralytics`, and friends), so the cleanest install is an
+**isolated** one that creates a dedicated environment and exposes just the
+`commonforms` command:
+
+```sh
+uv tool install commonforms
+# or
+pipx install commonforms
+```
+
+If you'd rather use it as a **library** inside an existing project, install it with
+`uv` or `pip`, feel free to choose your package manager flavor:
 
 ```sh
 uv pip install commonforms
+# or
+pip install commonforms
 ```
+
+> ⚠️ A plain `pip install` (or `uv pip install`) installs into your **active**
+> environment. Because the dependency set is large and pins recent versions, this can
+> upgrade packages like `numpy`, `pillow`, and `transformers` in place — so install
+> into a dedicated virtualenv/conda env, not a shared `base`.
 
 Once it's installed, you should be able to run the CLI command on ~any PDF.
 

--- a/commonforms/__main__.py
+++ b/commonforms/__main__.py
@@ -48,7 +48,7 @@ def main():
     parser.add_argument(
         "--fast",
         action="store_true",
-        help="If running on a CPU, you can use --fast to get a 50% speedup with a small accuracy penalty",
+        help="If running on a CPU, you can use --fast to get a 50%% speedup with a small accuracy penalty",
     )
     parser.add_argument(
         "--multiline",
@@ -58,7 +58,6 @@ def main():
 
     args = parser.parse_args()
 
-    print(f"**{args.confidence=}")
     prepare_form(
         args.input,
         args.output,


### PR DESCRIPTION
First off — thank you for building this. I switched from a $99/month SaaS to `commonforms` and it does the same job for free, so this PR is a small thank-you in the form of three tiny fixes I hit while getting set up.

### What
1. **Fix `commonforms --help` crash** — an unescaped `%` in the `--fast` argparse help string (`...50% speedup...`) made argparse treat it as a format specifier and dump the raw argument dict into the terminal instead of showing help. Escaped it to `50%%` so `--help` is just help again.
2. **Remove a leftover debug `print()`** — `print(f"**{args.confidence=}")` in `__main__.py` echoed `**args.confidence=0.3` to stdout on every run. Quietly retired.
3. **Docs: recommend an isolated install** — README now leads with `uv tool install commonforms` / `pipx install commonforms` so new users don't install into their active (e.g. conda `base`) environment by accident.

### Why
- The `--help` dict-dump was a surprise easter egg, but probably not the one you intended — it's the first thing a curious new user runs.
- The debug line added a little noise to every invocation.
- On #3 I'll be honest: I learned the hard way and `pip install`'d this straight into my conda `base`. Because the dependency set is large and pins recent majors (`transformers`, `pillow`, `torch`, `rfdetr`, `ultralytics`), it upgraded shared packages in place and disturbed some unrelated tooling. An isolated-install nudge up top would have saved me, and likely the next person too.

All three are small and self-contained — happy to split them into separate PRs if you'd prefer to review them independently.

Thanks again for putting this out there for free. It genuinely replaced a paid tool for me, and it was a pleasure to give a little back.
