### PR TITLE
Fix duplicate cross-class form detections

### DIFF
--- a/commonforms/inference.py
+++ b/commonforms/inference.py
@@ -158,6 +158,7 @@ class FFDNetDetector:
                 augment=True,
                 imgsz=image_size,
                 device=self.device,
+                agnostic_nms=True,
             )
 
         widgets = {}

--- a/tests/inference_test.py
+++ b/tests/inference_test.py
@@ -5,7 +5,7 @@ import formalpdf
 import pytest
 from PIL import Image
 
-from commonforms.inference import promote_signature_widgets
+from commonforms.inference import FFDNetDetector, promote_signature_widgets
 from commonforms.utils import BoundingBox, Page, TextFragment, Widget
 
 
@@ -69,6 +69,23 @@ def test_inference_ffdetr(tmp_path):
     assert len(doc[0].widgets()) > 0
 
     doc.document.close()
+
+
+def test_ffdnet_enables_class_agnostic_nms():
+    class Model:
+        def predict(self, source, **kwargs):
+            assert len(source) == 1
+            assert kwargs["agnostic_nms"] is True
+            return []
+
+    detector = FFDNetDetector.__new__(FFDNetDetector)
+    detector.device = "cpu"
+    detector.fast = False
+    detector.model = Model()
+
+    pages = [Page(image=Image.new("RGB", (1, 1)), width=1, height=1, text_fragments=[])]
+
+    assert detector.extract_widgets(pages) == {}
 
 
 def test_promote_signature_widgets_uses_signature_label_on_test_pdf():


### PR DESCRIPTION
## Summary

- enable class-agnostic NMS for the default FFDNet inference path
- add a regression test that locks the Ultralytics prediction option in place

## Problem

FFDNet currently uses Ultralytics' default class-aware NMS. When the same region
is detected as different field classes, such as a text field and a choice
button, the detections cannot suppress one another and can produce stacked
duplicate PDF fields.

## Change

Pass `agnostic_nms=True` to the default FFDNet prediction call so strongly
overlapping detections compete regardless of predicted class. The fast ONNX
path is unchanged.

## Validation

- `pytest -q`: 8 passed
- `ruff check tests/inference_test.py`: passed

The five existing Ruff findings in `commonforms/inference.py` are unchanged by
this PR.

## AI assistance disclosure

This change was developed with AI assistance. All changes were reviewed and
validated by the submitter using the test suite.
